### PR TITLE
Lammps reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ build*/
 .vscode/
 unittest/data/
 gen/
+.vs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,7 @@ source_group("ext" FILES ${EXT_FILES})
 source_group("shaders" FILES ${SHADER_FILES})
 source_group("proj" FILES ${PROJ_FILES})
 
-add_library(mdlib ${CORE_FILES} ${SRC_FILES} ${EXT_FILES} ${SHADER_FILES} ${PROJ_FILES} "src/md_lammps.h" "src/md_lammps.c")
+add_library(mdlib ${CORE_FILES} ${SRC_FILES} ${EXT_FILES} ${SHADER_FILES} ${PROJ_FILES})
 
 if (MD_LINK_STDLIB_STATIC)
     set(MD_PROPERTIES ${MD_PROPERTIES} MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,7 @@ source_group("ext" FILES ${EXT_FILES})
 source_group("shaders" FILES ${SHADER_FILES})
 source_group("proj" FILES ${PROJ_FILES})
 
-add_library(mdlib ${CORE_FILES} ${SRC_FILES} ${EXT_FILES} ${SHADER_FILES} ${PROJ_FILES})
+add_library(mdlib ${CORE_FILES} ${SRC_FILES} ${EXT_FILES} ${SHADER_FILES} ${PROJ_FILES} "src/md_lammps.h" "src/md_lammps.c")
 
 if (MD_LINK_STDLIB_STATIC)
     set(MD_PROPERTIES ${MD_PROPERTIES} MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 
 project(md_benchmark VERSION 0.1 LANGUAGES C)
 
-add_executable(md_benchmark benchmark.c "bench_lammps.c")
+add_executable(md_benchmark benchmark.c)
 
 target_compile_definitions(md_benchmark PRIVATE MD_BENCHMARK_DATA_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/../test_data\" ${MD_DEFINES})
 target_compile_options(md_benchmark PRIVATE ${MD_FLAGS} $<$<CONFIG:Debug>:${MD_FLAGS_DEB}> $<$<CONFIG:Release>:${MD_FLAGS_REL}>)
@@ -19,4 +19,5 @@ target_sources(md_benchmark
     ${CMAKE_CURRENT_SOURCE_DIR}/bench_xyz.c
     ${CMAKE_CURRENT_SOURCE_DIR}/bench_str.c
     ${CMAKE_CURRENT_SOURCE_DIR}/bench_util.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/bench_lammps.c
   )

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 
 project(md_benchmark VERSION 0.1 LANGUAGES C)
 
-add_executable(md_benchmark benchmark.c)
+add_executable(md_benchmark benchmark.c "bench_lammps.c")
 
 target_compile_definitions(md_benchmark PRIVATE MD_BENCHMARK_DATA_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/../test_data\" ${MD_DEFINES})
 target_compile_options(md_benchmark PRIVATE ${MD_FLAGS} $<$<CONFIG:Debug>:${MD_FLAGS_DEB}> $<$<CONFIG:Release>:${MD_FLAGS_REL}>)

--- a/benchmark/bench_lammps.c
+++ b/benchmark/bench_lammps.c
@@ -1,0 +1,27 @@
+#include "ubench.h"
+
+#include <md_lammps.h>
+#include <core/md_allocator.h>
+#include <core/md_arena_allocator.h>
+#include <core/md_os.h>
+
+UBENCH_EX(lammps, load) {
+	md_allocator_i* alloc = md_arena_allocator_create(md_heap_allocator, MEGABYTES(4));
+	str_t path = STR(MD_BENCHMARK_DATA_DIR "/Water_Ethane_Cubic_Init.data");
+
+	md_file_o* file = md_file_open(path, MD_FILE_READ);
+	UBENCH_SET_BYTES(md_file_size(file));
+	md_file_close(file);
+
+	data_format_t* formatPtr, format;
+	formatPtr = &format;
+	get_data_format(formatPtr, full);
+
+	UBENCH_DO_BENCHMARK() {
+		md_arena_allocator_reset(alloc);
+		md_lammps_data_t lammps = {0};
+		md_lammps_data_parse_file(&lammps, path, alloc, formatPtr);
+	}
+
+	md_arena_allocator_destroy(alloc);
+}

--- a/src/md_lammps.c
+++ b/src/md_lammps.c
@@ -118,13 +118,13 @@ static bool md_lammps_data_parse(md_lammps_data_t* data, md_buffered_reader_t* r
 				atom->z = (float)parse_float_wide(tokens[d].ptr, tokens[d].len);
 				break;
 			case NX:
-				atom->atom_type = (int32_t)parse_int_wide(tokens[d].ptr, tokens[d].len);
+				atom->nx = (int32_t)parse_int_wide(tokens[d].ptr, tokens[d].len);
 				break;
 			case NY:
-				atom->atom_type = (int32_t)parse_int_wide(tokens[d].ptr, tokens[d].len);
+				atom->ny = (int32_t)parse_int_wide(tokens[d].ptr, tokens[d].len);
 				break;
 			case NZ:
-				atom->atom_type = (int32_t)parse_int_wide(tokens[d].ptr, tokens[d].len);
+				atom->nz = (int32_t)parse_int_wide(tokens[d].ptr, tokens[d].len);
 				break;
 			}
 		}

--- a/src/md_lammps.c
+++ b/src/md_lammps.c
@@ -26,7 +26,7 @@ bool get_data_format(data_format_t* format, atom_style style) {
 }
 
 
-float get_mass(md_lammps_atom_mass_t* m, int32_t type, int32_t num_types)
+static float get_mass(md_lammps_atom_mass_t* m, int32_t type, int32_t num_types)
 {
 	for (int32_t i = 0; i < num_types; i++) {
 		if (m[i].atom_type == type) {
@@ -34,7 +34,7 @@ float get_mass(md_lammps_atom_mass_t* m, int32_t type, int32_t num_types)
 		}
 	}
 	MD_LOG_ERROR("atom type could not be found");
-	return -1.0f;
+	return 0.0f;
 }
 
 

--- a/src/md_lammps.c
+++ b/src/md_lammps.c
@@ -427,9 +427,9 @@ bool md_lammps_molecule_init(md_molecule_t* mol, const md_lammps_data_t* data, m
 
 	int32_t cur_res_id = -1;
 	for (int64_t i = 0; i < num_atoms; ++i) {
-		const float x = data->atom_data[i].x * 10.0f; // convert from nm to Ångström
-		const float y = data->atom_data[i].y * 10.0f; // convert from nm to Ångström
-		const float z = data->atom_data[i].z * 10.0f; // convert from nm to Ångström
+		const float x = data->atom_data[i].x;
+		const float y = data->atom_data[i].y;
+		const float z = data->atom_data[i].z;
 
 		int32_t res_id = data->atom_data[i].mol_idx;
 		if (res_id != cur_res_id) {
@@ -463,7 +463,7 @@ bool md_lammps_molecule_init(md_molecule_t* mol, const md_lammps_data_t* data, m
 	if (!md_util_element_from_mass(mol->atom.element, mol->atom.mass, num_atoms)) MD_LOG_ERROR("One or more masses are missing matching element");
 
 	//Create unit cell
-	mol->unit_cell = md_util_unit_cell_from_triclinic(data->cell_ext[0] * 10.0, data->cell_ext[1] * 10.0, data->cell_ext[2] * 10.0, data->xy * 10.0, data->xz * 10.0, data->yz * 10.0);
+	mol->unit_cell = md_util_unit_cell_from_triclinic(data->cell_ext[0], data->cell_ext[1], data->cell_ext[2], data->xy, data->xz, data->yz);
 	return true;
 }
 

--- a/src/md_lammps.c
+++ b/src/md_lammps.c
@@ -59,9 +59,10 @@ static bool md_lammps_data_parse(md_lammps_data_t* data, md_buffered_reader_t* r
 	md_array_resize(data->atom_data, data->num_atoms, alloc);
 
 	//Jump ahead to the Atoms definition
+	int32_t atoms_line_counter = 0;
 	do {
 		md_buffered_reader_extract_line(&line, reader);
-	} while (!str_equal_cstr_n(line, "Atoms", 5));
+	} while (!str_equal_cstr_n(line, "Atoms", 5) && atoms_line_counter++ < 1000);
 
 	//Skip empty line
 	md_buffered_reader_skip_line(reader);

--- a/src/md_lammps.c
+++ b/src/md_lammps.c
@@ -62,7 +62,11 @@ static bool md_lammps_data_parse(md_lammps_data_t* data, md_buffered_reader_t* r
 	int32_t atoms_line_counter = 0;
 	do {
 		md_buffered_reader_extract_line(&line, reader);
-	} while (!str_equal_cstr_n(line, "Atoms", 5) && atoms_line_counter++ < 1000);
+		if (atoms_line_counter++ >= 1000) {
+			MD_LOG_ERROR("Could not find atoms line after 1000 lines");
+			return false;
+		}
+	} while (!str_equal_cstr_n(line, "Atoms", 5));
 
 	//Skip empty line
 	md_buffered_reader_skip_line(reader);

--- a/src/md_lammps.c
+++ b/src/md_lammps.c
@@ -12,18 +12,16 @@
 
 #include <string.h>
 
-data_format_t* get_data_format(atom_style style) {
-	data_format_t* df;
+bool get_data_format(data_format_t* format, atom_style style) {
 	switch (style)
 	{
 	default:
 		MD_LOG_ERROR("Invalid atom_style");
-		break;
+		return false;
 	case full:
-		data_format_t arr[10] = { ATOM_IDX, MOL_IDX, ATOM_TYPE, PARTIAL_CHARGE, ATOM_X, ATOM_Y, ATOM_Z, NX, NY, NZ };
-		df->len = 10;
-		df->ptr = arr;
-		return df;
+		format->ptr = DATA_FORMAT_FULL;
+		format->len = ARRAY_SIZE(DATA_FORMAT_FULL);
+		return true;
 	}
 }
 
@@ -63,7 +61,7 @@ static bool md_lammps_data_parse(md_lammps_data_t* data, md_buffered_reader_t* r
 	//Jump ahead to the Atoms definition
 	do {
 		md_buffered_reader_extract_line(&line, reader);
-	} while (!str_equal_cstr_n(line, "ATOMS", 5));
+	} while (!str_equal_cstr_n(line, "Atoms", 5));
 
 	//Skip empty line
 	md_buffered_reader_skip_line(reader);

--- a/src/md_lammps.c
+++ b/src/md_lammps.c
@@ -1,0 +1,174 @@
+#include <md_lammps.h>
+
+#include <md_util.h>
+
+#include <core/md_common.h>
+#include <core/md_str.h>
+#include <core/md_allocator.h>
+#include <core/md_log.h>
+#include <core/md_os.h>
+#include <core/md_array.h>
+#include <core/md_parse.h>
+
+#include <string.h>
+
+static bool md_lammps_data_parse(md_lammps_data_t* data, md_buffered_reader_t* reader, struct md_allocator_i* alloc, data_format_t* data_format) {
+	ASSERT(data);
+	ASSERT(reader);
+	ASSERT(alloc);
+	str_t line;
+	str_t tokens[16];
+
+	//lammps_atom_data_structure test_data_structure[] = { ATOM_IDX, MOL_IDX, ATOM_TYPE, PARTIAL_CHARGE, ATOM_COORD, ATOM_COORD, ATOM_COORD };
+
+	//Read the title of the file
+	if (!md_buffered_reader_extract_line(&line, reader)) {
+		MD_LOG_ERROR("Failed to parse lammps title");
+		return false;
+	}
+	str_copy_to_char_buf(data->title, sizeof(data->title), str_trim(line));
+
+	//Skip empty line
+	md_buffered_reader_skip_line(reader);
+
+	//Read the number of atoms
+	if (!md_buffered_reader_extract_line(&line, reader)) {
+		MD_LOG_ERROR("Failed to parse LAMMPS num atoms");
+		return false;
+	}
+
+	data->num_atoms = parse_int(str_trim(line));
+	if (!data->num_atoms) {
+		MD_LOG_ERROR("Failed to parse LAMMPS num atoms");
+		return false;
+	}
+
+	md_array_resize(data->atom_data, data->num_atoms, alloc);
+
+	//Jump ahead to the Atoms definition
+	do {
+		md_buffered_reader_extract_line(&line, reader);
+	} while (!str_equal_cstr_n(line, "ATOMS", 5));
+
+	//Skip empty line
+	md_buffered_reader_skip_line(reader);
+
+	//Start reading the atom data
+	for (int64_t i = 0; i < data->num_atoms; ++i) {
+		if (!md_buffered_reader_extract_line(&line, reader)) {
+			MD_LOG_ERROR("Failed to extract atom line");
+			return false;
+		}
+		const int64_t num_tokens = extract_tokens(tokens, ARRAY_SIZE(tokens), &line);
+		if (num_tokens < data_format->len) {
+			MD_LOG_ERROR("Failed to parse atom coordinates, expected at least %i tokens, got %i", (int)data_format->len, (int)num_tokens);
+			return false;
+		}
+
+		md_lammps_atom_t* atom = &data->atom_data[i];
+
+		/*
+		ATOM_IDX,
+		MOL_IDX,
+		ATOM_TYPE,
+		PARTIAL_CHARGE,
+		ATOM_COORD
+		*/
+
+		for (int64_t d = 0; d < data_format->len; d++) {
+			switch (data_format->ptr[d])
+			{
+			default:
+				MD_LOG_ERROR("Failed to read atom data format");
+				return false;
+			case ATOM_IDX:
+				atom->atom_idx = (int32_t)parse_int_wide(tokens[d].ptr, tokens[d].len);
+				break;
+			case MOL_IDX:
+				atom->mol_idx = (int32_t)parse_int_wide(tokens[d].ptr, tokens[d].len);
+				break;
+			case ATOM_TYPE:
+				atom->atom_type = (int32_t)parse_int_wide(tokens[d].ptr, tokens[d].len);
+				break;
+			case PARTIAL_CHARGE:
+				atom->partial_charge = (float)parse_float_wide(tokens[d].ptr, tokens[d].len);
+				break;
+			case ATOM_X:
+				atom->x = (float)parse_float_wide(tokens[d].ptr, tokens[d].len);
+				break;
+			case ATOM_Y:
+				atom->y = (float)parse_float_wide(tokens[d].ptr, tokens[d].len);
+				break;
+			case ATOM_Z:
+				atom->z = (float)parse_float_wide(tokens[d].ptr, tokens[d].len);
+				break;
+			case NX:
+				atom->atom_type = (int32_t)parse_int_wide(tokens[d].ptr, tokens[d].len);
+				break;
+			case NY:
+				atom->atom_type = (int32_t)parse_int_wide(tokens[d].ptr, tokens[d].len);
+				break;
+			case NZ:
+				atom->atom_type = (int32_t)parse_int_wide(tokens[d].ptr, tokens[d].len);
+				break;
+			}
+		}
+
+		//str_copy_to_char_buf(atom->atom_type, sizeof(atom->atom_type), str_trim(str_substr(line, 5, 5)));
+		//str_copy_to_char_buf(atom->atom_name, sizeof(atom->atom_name), str_trim(str_substr(line, 10, 5)));
+	}
+	/*
+
+	if (!md_buffered_reader_extract_line(&line, reader)) {
+		MD_LOG_ERROR("Failed to extract unitcell line");
+		return false;
+	}
+
+	const int64_t num_tokens = extract_float_tokens(tokens, ARRAY_SIZE(tokens), line);
+
+	if (num_tokens != 3) {
+		MD_LOG_ERROR("Failed to parse cell extent, expected 3 tokens, got %i", (int)num_tokens);
+		return false;
+	}
+
+	data->cell_ext[0] = (float)parse_float(tokens[0]);
+	data->cell_ext[1] = (float)parse_float(tokens[1]);
+	data->cell_ext[2] = (float)parse_float(tokens[2]);
+
+	*/
+
+	return true;
+}
+
+bool md_lammps_data_parse_str(md_lammps_data_t* data, str_t str, struct md_allocator_i* alloc, data_format_t* data_format) {
+	ASSERT(data);
+	ASSERT(alloc);
+
+	md_buffered_reader_t line_reader = md_buffered_reader_from_str(str);
+	return md_lammps_data_parse(data, &line_reader, alloc, data_format);
+}
+
+bool md_lammps_data_parse_file(md_lammps_data_t* data, str_t filename, struct md_allocator_i* alloc, data_format_t* data_format) {
+	bool result = false;
+	md_file_o* file = md_file_open(filename, MD_FILE_READ | MD_FILE_BINARY);
+	if (file) {
+		const int64_t cap = MEGABYTES(1);
+		char* buf = md_alloc(md_heap_allocator, cap);
+
+		md_buffered_reader_t line_reader = md_buffered_reader_from_file(buf, cap, file);
+		result = md_lammps_data_parse(data, &line_reader, alloc, data_format);
+
+		md_free(md_heap_allocator, buf, cap);
+		md_file_close(file);
+	}
+	else {
+		MD_LOG_ERROR("Could not open file '%.*s'", filename.len, filename.ptr);
+	}
+	return result;
+}
+
+void md_lammps_data_free(md_lammps_data_t* data, struct md_allocator_i* alloc) {
+	ASSERT(data);
+	if (data->atom_data) md_array_free(data->atom_data, alloc);
+	MEMSET(data, 0, sizeof(md_lammps_data_t));
+}

--- a/src/md_lammps.c
+++ b/src/md_lammps.c
@@ -68,6 +68,8 @@ static bool md_lammps_data_parse(md_lammps_data_t* data, md_buffered_reader_t* r
 		return false;
 	}
 
+	md_array_resize(data->atom_type_mass, data->num_atom_types, alloc);
+
 	//Read num bonds
 	if (!md_buffered_reader_extract_line(&line, reader)) {
 		MD_LOG_ERROR("Failed to parse LAMMPS num bonds");
@@ -159,10 +161,16 @@ static bool md_lammps_data_parse(md_lammps_data_t* data, md_buffered_reader_t* r
 			return false;
 		}
 
-		md_lammps_atom_mass_t* mass = &data->atom_type_mass;
+		md_lammps_atom_mass_t* mass = &data->atom_type_mass[i];
 
 		mass->atom_idx = (int32_t)parse_int(tokens[0]);
-		mass->mass = (int32_t)parse_float(tokens[1]);
+		/*
+		if (!data->atom_type_mass->atom_idx) {
+			MD_LOG_ERROR("Atom mass index was not written to data");
+			return false;
+		}
+		*/
+		mass->mass = (float)parse_float(tokens[1]);
 	}
 
 	//Jump ahead to the Atoms definition

--- a/src/md_lammps.c
+++ b/src/md_lammps.c
@@ -100,35 +100,37 @@ static bool md_lammps_data_parse(md_lammps_data_t* data, md_buffered_reader_t* r
 				MD_LOG_ERROR("Failed to read atom data format");
 				return false;
 			case ATOM_IDX:
-				atom->atom_idx = (int32_t)parse_int_wide(tokens[d].ptr, tokens[d].len);
+				atom->atom_idx = (int32_t)parse_int(tokens[d]);
 				break;
 			case MOL_IDX:
-				atom->mol_idx = (int32_t)parse_int_wide(tokens[d].ptr, tokens[d].len);
+				atom->mol_idx = (int32_t)parse_int(tokens[d]);
 				break;
 			case ATOM_TYPE:
-				atom->atom_type = (int32_t)parse_int_wide(tokens[d].ptr, tokens[d].len);
+				atom->atom_type = (int32_t)parse_int(tokens[d]);
 				break;
 			case PARTIAL_CHARGE:
-				atom->partial_charge = (float)parse_float_wide(tokens[d].ptr, tokens[d].len);
+				atom->partial_charge = (float)parse_float(tokens[d]);
 				break;
 			case ATOM_X:
-				atom->x = (float)parse_float_wide(tokens[d].ptr, tokens[d].len);
+				atom->x = (float)parse_float(tokens[d]);
 				break;
 			case ATOM_Y:
-				atom->y = (float)parse_float_wide(tokens[d].ptr, tokens[d].len);
+				atom->y = (float)parse_float(tokens[d]);
 				break;
 			case ATOM_Z:
-				atom->z = (float)parse_float_wide(tokens[d].ptr, tokens[d].len);
+				atom->z = (float)parse_float(tokens[d]);
 				break;
 			case NX:
-				atom->nx = (int32_t)parse_int_wide(tokens[d].ptr, tokens[d].len);
+				atom->nx = (int32_t)parse_int(tokens[d]);
 				break;
 			case NY:
-				atom->ny = (int32_t)parse_int_wide(tokens[d].ptr, tokens[d].len);
+				atom->ny = (int32_t)parse_int(tokens[d]);
 				break;
 			case NZ:
-				atom->nz = (int32_t)parse_int_wide(tokens[d].ptr, tokens[d].len);
+				atom->nz = (int32_t)parse_int(tokens[d]);
 				break;
+			case res_name:
+				str_copy_to_char_buf(atom->res_name, sizeof(atom->res_name), tokens[d]);
 			}
 		}
 

--- a/src/md_lammps.c
+++ b/src/md_lammps.c
@@ -452,7 +452,7 @@ bool md_lammps_molecule_init(md_molecule_t* mol, const md_lammps_data_t* data, m
 	return true;
 }
 
-static bool lammps_init_from_str(md_molecule_t* mol, str_t str, md_allocator_i* alloc, data_format_t* format) {
+bool md_lammps_init_from_str(md_molecule_t* mol, str_t str, md_allocator_i* alloc, data_format_t* format) {
 	md_lammps_data_t data = { 0 };
 	bool success = false;
 	if (md_lammps_data_parse_str(&data, str, md_heap_allocator, format)) {
@@ -463,7 +463,7 @@ static bool lammps_init_from_str(md_molecule_t* mol, str_t str, md_allocator_i* 
 	return success;
 }
 
-static bool lammps_init_from_file(md_molecule_t* mol, str_t filename, md_allocator_i* alloc, data_format_t* format) {
+bool md_lammps_init_from_file(md_molecule_t* mol, str_t filename, md_allocator_i* alloc, data_format_t* format) {
 	md_lammps_data_t data = { 0 };
 	bool success = false;
 	if (md_lammps_data_parse_file(&data, filename, md_heap_allocator, format)) {

--- a/src/md_lammps.c
+++ b/src/md_lammps.c
@@ -35,252 +35,283 @@ static bool md_lammps_data_parse(md_lammps_data_t* data, md_buffered_reader_t* r
 	//lammps_atom_data_structure test_data_structure[] = { ATOM_IDX, MOL_IDX, ATOM_TYPE, PARTIAL_CHARGE, ATOM_COORD, ATOM_COORD, ATOM_COORD };
 
 	//Read the title of the file
-	if (!md_buffered_reader_extract_line(&line, reader)) {
-		MD_LOG_ERROR("Failed to parse lammps title");
-		return false;
-	}
-	str_copy_to_char_buf(data->title, sizeof(data->title), str_trim(line));
+	{
+		if (!md_buffered_reader_extract_line(&line, reader)) {
+			MD_LOG_ERROR("Failed to parse lammps title");
+			return false;
+		}
+		str_copy_to_char_buf(data->title, sizeof(data->title), str_trim(line));
 
-	//Skip empty line
-	md_buffered_reader_skip_line(reader);
+		//Skip empty line
+		md_buffered_reader_skip_line(reader);
+	}
 
 	//Read the number of atoms
-	if (!md_buffered_reader_extract_line(&line, reader)) {
-		MD_LOG_ERROR("Failed to parse LAMMPS num atoms");
-		return false;
-	}
-	data->num_atoms = parse_int(str_trim(line));
-	if (!data->num_atoms) {
-		MD_LOG_ERROR("Failed to parse LAMMPS num atoms");
-		return false;
-	}
+	{
+		if (!md_buffered_reader_extract_line(&line, reader)) {
+			MD_LOG_ERROR("Failed to parse LAMMPS num atoms");
+			return false;
+		}
+		data->num_atoms = parse_int(str_trim(line));
+		if (!data->num_atoms) {
+			MD_LOG_ERROR("Failed to parse LAMMPS num atoms");
+			return false;
+		}
 
-	md_array_resize(data->atom_data, data->num_atoms, alloc);
+		md_array_resize(data->atom_data, data->num_atoms, alloc);
+	}
 
 	//Read num atom types
-	if (!md_buffered_reader_extract_line(&line, reader)) {
-		MD_LOG_ERROR("Failed to parse LAMMPS num atom types");
-		return false;
+	{
+		if (!md_buffered_reader_extract_line(&line, reader)) {
+			MD_LOG_ERROR("Failed to parse LAMMPS num atom types");
+			return false;
+		}
+		data->num_atom_types = (int32_t)parse_int(str_trim(line));
+		if (!data->num_atom_types) {
+			MD_LOG_ERROR("Failed to parse LAMMPS num atom types");
+			return false;
+		}
+		md_array_resize(data->atom_type_mass, data->num_atom_types, alloc);
 	}
-	data->num_atom_types = parse_int(str_trim(line));
-	if (!data->num_atom_types) {
-		MD_LOG_ERROR("Failed to parse LAMMPS num atom types");
-		return false;
-	}
-
-	md_array_resize(data->atom_type_mass, data->num_atom_types, alloc);
 
 	//Read num bonds
-	if (!md_buffered_reader_extract_line(&line, reader)) {
-		MD_LOG_ERROR("Failed to parse LAMMPS num bonds");
-		return false;
-	}
-	data->num_bonds = parse_int(str_trim(line));
-	if (!data->num_bonds) {
-		MD_LOG_ERROR("Failed to parse LAMMPS num bonds");
-		return false;
-	}
+	{
+		if (!md_buffered_reader_extract_line(&line, reader)) {
+			MD_LOG_ERROR("Failed to parse LAMMPS num bonds");
+			return false;
+		}
+		data->num_bonds = parse_int(str_trim(line));
+		if (!data->num_bonds) {
+			MD_LOG_ERROR("Failed to parse LAMMPS num bonds");
+			return false;
+		}
 
-	md_array_resize(data->bonds, data->num_bonds, alloc);
+		md_array_resize(data->bonds, data->num_bonds, alloc);
+	}
 
 	//Read num bond types
-	if (!md_buffered_reader_extract_line(&line, reader)) {
-		MD_LOG_ERROR("Failed to parse LAMMPS num bond types");
-		return false;
-	}
-	data->num_bond_types = parse_int(str_trim(line));
-	if (!data->num_bond_types) {
-		MD_LOG_ERROR("Failed to parse LAMMPS num bond types");
-		return false;
+	{
+		if (!md_buffered_reader_extract_line(&line, reader)) {
+			MD_LOG_ERROR("Failed to parse LAMMPS num bond types");
+			return false;
+		}
+		data->num_bond_types = (int32_t)parse_int(str_trim(line));
+		if (!data->num_bond_types) {
+			MD_LOG_ERROR("Failed to parse LAMMPS num bond types");
+			return false;
+		}
 	}
 
 	//Read num angles
-	if (!md_buffered_reader_extract_line(&line, reader)) {
-		MD_LOG_ERROR("Failed to parse LAMMPS num angles");
-		return false;
-	}
-	data->num_angles = parse_int(str_trim(line));
-	if (!data->num_angles) {
-		MD_LOG_ERROR("Failed to parse LAMMPS num angles");
-		return false;
+	{
+		if (!md_buffered_reader_extract_line(&line, reader)) {
+			MD_LOG_ERROR("Failed to parse LAMMPS num angles");
+			return false;
+		}
+		data->num_angles = parse_int(str_trim(line));
+		if (!data->num_angles) {
+			MD_LOG_ERROR("Failed to parse LAMMPS num angles");
+			return false;
+		}
 	}
 
 	//Read num angle types
-	if (!md_buffered_reader_extract_line(&line, reader)) {
-		MD_LOG_ERROR("Failed to parse LAMMPS num angle types");
-		return false;
-	}
-	data->num_angle_types = parse_int(str_trim(line));
-	if (!data->num_angle_types) {
-		MD_LOG_ERROR("Failed to parse LAMMPS num angle types");
-		return false;
+	{
+		if (!md_buffered_reader_extract_line(&line, reader)) {
+			MD_LOG_ERROR("Failed to parse LAMMPS num angle types");
+			return false;
+		}
+		data->num_angle_types = (int32_t)parse_int(str_trim(line));
+		if (!data->num_angle_types) {
+			MD_LOG_ERROR("Failed to parse LAMMPS num angle types");
+			return false;
+		}
 	}
 
 	//Read num dihedrals
-	if (!md_buffered_reader_extract_line(&line, reader)) {
-		MD_LOG_ERROR("Failed to parse LAMMPS num dihedrals");
-		return false;
-	}
-	data->num_dihedrals = parse_int(str_trim(line));
-	if (!data->num_dihedrals) {
-		MD_LOG_ERROR("Failed to parse LAMMPS num dihedrals");
-		return false;
+	{
+		if (!md_buffered_reader_extract_line(&line, reader)) {
+			MD_LOG_ERROR("Failed to parse LAMMPS num dihedrals");
+			return false;
+		}
+		data->num_dihedrals = parse_int(str_trim(line));
+		if (!data->num_dihedrals) {
+			MD_LOG_ERROR("Failed to parse LAMMPS num dihedrals");
+			return false;
+		}
 	}
 
 	//Read num dihedral types
-	if (!md_buffered_reader_extract_line(&line, reader)) {
-		MD_LOG_ERROR("Failed to parse LAMMPS num dihedral types");
-		return false;
-	}
-	data->num_dihedral_types = parse_int(str_trim(line));
-	if (!data->num_dihedral_types) {
-		MD_LOG_ERROR("Failed to parse LAMMPS num dihedral types");
-		return false;
-	}
-
-	//Jump ahead to the Masses definition
-	do {
-		
+	{
 		if (!md_buffered_reader_extract_line(&line, reader)) {
-			MD_LOG_ERROR("Could not find Masses line");
+			MD_LOG_ERROR("Failed to parse LAMMPS num dihedral types");
 			return false;
 		}
-	} while (!str_equal_cstr_n(line, "Masses", 6));
-
-	//Skip empty line
-	md_buffered_reader_skip_line(reader);
-
-	//Start reading the Masses data
-
-	for (int32_t i = 0; i < data->num_atom_types; i++) {
-		if (!md_buffered_reader_extract_line(&line, reader)) {
-			MD_LOG_ERROR("Failed to extract mass line");
+		data->num_dihedral_types = (int32_t)parse_int(str_trim(line));
+		if (!data->num_dihedral_types) {
+			MD_LOG_ERROR("Failed to parse LAMMPS num dihedral types");
 			return false;
 		}
-		if (extract_tokens(tokens, 2, &line) != 2) {
-			MD_LOG_ERROR("Wrong amount of mass tokens");
-			return false;
-		}
-
-		md_lammps_atom_mass_t* mass = &data->atom_type_mass[i];
-
-		mass->atom_idx = (int32_t)parse_int(tokens[0]);
-		/*
-		if (!data->atom_type_mass->atom_idx) {
-			MD_LOG_ERROR("Atom mass index was not written to data");
-			return false;
-		}
-		*/
-		mass->mass = (float)parse_float(tokens[1]);
 	}
 
-	//Jump ahead to the Atoms definition
-	do {
-		
-		if (!md_buffered_reader_extract_line(&line, reader)) {
-			MD_LOG_ERROR("Could not find Atoms line");
-			return false;
-		}
-	} while (!str_equal_cstr_n(line, "Atoms", 5));
+	//Mass parsing
+	{
+		//Jump ahead to the Masses definition
+		{
+			do {
 
-	//Skip empty line
-	md_buffered_reader_skip_line(reader);
+				if (!md_buffered_reader_extract_line(&line, reader)) {
+					MD_LOG_ERROR("Could not find Masses line");
+					return false;
+				}
+			} while (!str_equal_cstr_n(line, "Masses", 6));
 
-	//Start reading the atom data
-	for (int64_t i = 0; i < data->num_atoms; ++i) {
-		if (!md_buffered_reader_extract_line(&line, reader)) {
-			MD_LOG_ERROR("Failed to extract atom line");
-			return false;
-		}
-		const int64_t num_tokens = extract_tokens(tokens, ARRAY_SIZE(tokens), &line);
-		if (num_tokens < data_format->len) {
-			MD_LOG_ERROR("Failed to parse atom coordinates, expected at least %i tokens, got %i", (int)data_format->len, (int)num_tokens);
-			return false;
+			//Skip empty line
+			md_buffered_reader_skip_line(reader);
 		}
 
-		md_lammps_atom_t* atom = &data->atom_data[i];
-
-		/*
-		ATOM_IDX,
-		MOL_IDX,
-		ATOM_TYPE,
-		PARTIAL_CHARGE,
-		ATOM_COORD
-		*/
-
-		for (int64_t d = 0; d < data_format->len; d++) {
-			switch (data_format->ptr[d])
-			{
-			default:
-				MD_LOG_ERROR("Failed to read atom data format");
+		//Start reading the Masses data
+		for (int32_t i = 0; i < data->num_atom_types; i++) {
+			if (!md_buffered_reader_extract_line(&line, reader)) {
+				MD_LOG_ERROR("Failed to extract mass line");
 				return false;
-			case ATOM_IDX:
-				atom->atom_idx = (int32_t)parse_int(tokens[d]);
-				break;
-			case MOL_IDX:
-				atom->mol_idx = (int32_t)parse_int(tokens[d]);
-				break;
-			case ATOM_TYPE:
-				atom->atom_type = (int32_t)parse_int(tokens[d]);
-				break;
-			case PARTIAL_CHARGE:
-				atom->partial_charge = (float)parse_float(tokens[d]);
-				break;
-			case ATOM_X:
-				atom->x = (float)parse_float(tokens[d]);
-				break;
-			case ATOM_Y:
-				atom->y = (float)parse_float(tokens[d]);
-				break;
-			case ATOM_Z:
-				atom->z = (float)parse_float(tokens[d]);
-				break;
-			case NX:
-				atom->nx = (int32_t)parse_int(tokens[d]);
-				break;
-			case NY:
-				atom->ny = (int32_t)parse_int(tokens[d]);
-				break;
-			case NZ:
-				atom->nz = (int32_t)parse_int(tokens[d]);
-				break;
-			case res_name:
-				str_copy_to_char_buf(atom->res_name, sizeof(atom->res_name), tokens[d]);
 			}
-		}
+			if (extract_tokens(tokens, 2, &line) != 2) {
+				MD_LOG_ERROR("Wrong amount of mass tokens");
+				return false;
+			}
 
-		//str_copy_to_char_buf(atom->atom_type, sizeof(atom->atom_type), str_trim(str_substr(line, 5, 5)));
-		//str_copy_to_char_buf(atom->atom_name, sizeof(atom->atom_name), str_trim(str_substr(line, 10, 5)));
+			md_lammps_atom_mass_t* mass = &data->atom_type_mass[i];
+
+			mass->atom_idx = (int32_t)parse_int(tokens[0]);
+			/*
+			if (!data->atom_type_mass->atom_idx) {
+				MD_LOG_ERROR("Atom mass index was not written to data");
+				return false;
+			}
+			*/
+			mass->mass = (float)parse_float(tokens[1]);
+		}
 	}
 
-	//Jump ahead to the Bonds definition
-	do {
-		
-		if (!md_buffered_reader_extract_line(&line, reader)) {
-			MD_LOG_ERROR("Could not find Bonds line");
-			return false;
-		}
-	} while (!str_equal_cstr_n(line, "Bonds", 5));
-	//Skip empty line
-	md_buffered_reader_skip_line(reader);
+	//Atom parsing
+	{
+		//Jump ahead to the Atoms definition
+		{
+			do {
 
-	//Start reading the bonds
-	for (int32_t i = 0; i < data->num_bonds; i++) {
-		if (!md_buffered_reader_extract_line(&line, reader)) {
-			MD_LOG_ERROR("Failed to extract bond line");
-			return false;
-		}
-		if (extract_tokens(tokens, 4, &line) != 4) {
-			MD_LOG_ERROR("Wrong amount of bond tokens");
-			return false;
+				if (!md_buffered_reader_extract_line(&line, reader)) {
+					MD_LOG_ERROR("Could not find Atoms line");
+					return false;
+				}
+			} while (!str_equal_cstr_n(line, "Atoms", 5));
+
+			//Skip empty line
+			md_buffered_reader_skip_line(reader);
 		}
 
-		md_lammps_atom_bond_t* bond = &data->bonds[i];
+		//Start reading the atom data
+		for (int64_t i = 0; i < data->num_atoms; ++i) {
+			if (!md_buffered_reader_extract_line(&line, reader)) {
+				MD_LOG_ERROR("Failed to extract atom line");
+				return false;
+			}
+			const int64_t num_tokens = extract_tokens(tokens, ARRAY_SIZE(tokens), &line);
+			if (num_tokens < data_format->len) {
+				MD_LOG_ERROR("Failed to parse atom coordinates, expected at least %i tokens, got %i", (int)data_format->len, (int)num_tokens);
+				return false;
+			}
 
-		bond->bond_idx = (int64_t)parse_int(tokens[0]);
-		bond->bond_type = (int32_t)parse_int(tokens[1]);
-		bond->first_atom_idx = (int64_t)parse_int(tokens[2]);
-		bond->second_atom_idx = (int64_t)parse_int(tokens[3]);
+			md_lammps_atom_t* atom = &data->atom_data[i];
+
+			/*
+			ATOM_IDX,
+			MOL_IDX,
+			ATOM_TYPE,
+			PARTIAL_CHARGE,
+			ATOM_COORD
+			*/
+
+			for (int64_t d = 0; d < data_format->len; d++) {
+				switch (data_format->ptr[d])
+				{
+				default:
+					MD_LOG_ERROR("Failed to read atom data format");
+					return false;
+				case ATOM_IDX:
+					atom->atom_idx = (int32_t)parse_int(tokens[d]);
+					break;
+				case MOL_IDX:
+					atom->mol_idx = (int32_t)parse_int(tokens[d]);
+					break;
+				case ATOM_TYPE:
+					atom->atom_type = (int32_t)parse_int(tokens[d]);
+					break;
+				case PARTIAL_CHARGE:
+					atom->partial_charge = (float)parse_float(tokens[d]);
+					break;
+				case ATOM_X:
+					atom->x = (float)parse_float(tokens[d]);
+					break;
+				case ATOM_Y:
+					atom->y = (float)parse_float(tokens[d]);
+					break;
+				case ATOM_Z:
+					atom->z = (float)parse_float(tokens[d]);
+					break;
+				case NX:
+					atom->nx = (int32_t)parse_int(tokens[d]);
+					break;
+				case NY:
+					atom->ny = (int32_t)parse_int(tokens[d]);
+					break;
+				case NZ:
+					atom->nz = (int32_t)parse_int(tokens[d]);
+					break;
+				case res_name:
+					str_copy_to_char_buf(atom->res_name, sizeof(atom->res_name), tokens[d]);
+				}
+			}
+
+			//str_copy_to_char_buf(atom->atom_type, sizeof(atom->atom_type), str_trim(str_substr(line, 5, 5)));
+			//str_copy_to_char_buf(atom->atom_name, sizeof(atom->atom_name), str_trim(str_substr(line, 10, 5)));
+		}
+	}
+
+	//Bonds parsing
+	{
+		//Jump ahead to the Bonds definition
+		{
+			do {
+
+				if (!md_buffered_reader_extract_line(&line, reader)) {
+					MD_LOG_ERROR("Could not find Bonds line");
+					return false;
+				}
+			} while (!str_equal_cstr_n(line, "Bonds", 5));
+			//Skip empty line
+			md_buffered_reader_skip_line(reader);
+		}
+
+		//Start reading the bonds
+		for (int32_t i = 0; i < data->num_bonds; i++) {
+			if (!md_buffered_reader_extract_line(&line, reader)) {
+				MD_LOG_ERROR("Failed to extract bond line");
+				return false;
+			}
+			if (extract_tokens(tokens, 4, &line) != 4) {
+				MD_LOG_ERROR("Wrong amount of bond tokens");
+				return false;
+			}
+
+			md_lammps_atom_bond_t* bond = &data->bonds[i];
+
+			bond->bond_idx = (int64_t)parse_int(tokens[0]);
+			bond->bond_type = (int32_t)parse_int(tokens[1]);
+			bond->first_atom_idx = (int64_t)parse_int(tokens[2]);
+			bond->second_atom_idx = (int64_t)parse_int(tokens[3]);
+		}
 	}
 
 	/*

--- a/src/md_lammps.c
+++ b/src/md_lammps.c
@@ -49,7 +49,6 @@ static bool md_lammps_data_parse(md_lammps_data_t* data, md_buffered_reader_t* r
 		MD_LOG_ERROR("Failed to parse LAMMPS num atoms");
 		return false;
 	}
-
 	data->num_atoms = parse_int(str_trim(line));
 	if (!data->num_atoms) {
 		MD_LOG_ERROR("Failed to parse LAMMPS num atoms");
@@ -57,6 +56,114 @@ static bool md_lammps_data_parse(md_lammps_data_t* data, md_buffered_reader_t* r
 	}
 
 	md_array_resize(data->atom_data, data->num_atoms, alloc);
+
+	//Read num atom types
+	if (!md_buffered_reader_extract_line(&line, reader)) {
+		MD_LOG_ERROR("Failed to parse LAMMPS num atom types");
+		return false;
+	}
+	data->num_atom_types = parse_int(str_trim(line));
+	if (!data->num_atom_types) {
+		MD_LOG_ERROR("Failed to parse LAMMPS num atom types");
+		return false;
+	}
+
+	//Read num bonds
+	if (!md_buffered_reader_extract_line(&line, reader)) {
+		MD_LOG_ERROR("Failed to parse LAMMPS num bonds");
+		return false;
+	}
+	data->num_bonds = parse_int(str_trim(line));
+	if (!data->num_bonds) {
+		MD_LOG_ERROR("Failed to parse LAMMPS num bonds");
+		return false;
+	}
+
+	//Read num bond types
+	if (!md_buffered_reader_extract_line(&line, reader)) {
+		MD_LOG_ERROR("Failed to parse LAMMPS num bond types");
+		return false;
+	}
+	data->num_bond_types = parse_int(str_trim(line));
+	if (!data->num_bond_types) {
+		MD_LOG_ERROR("Failed to parse LAMMPS num bond types");
+		return false;
+	}
+
+	//Read num angles
+	if (!md_buffered_reader_extract_line(&line, reader)) {
+		MD_LOG_ERROR("Failed to parse LAMMPS num angles");
+		return false;
+	}
+	data->num_angles = parse_int(str_trim(line));
+	if (!data->num_angles) {
+		MD_LOG_ERROR("Failed to parse LAMMPS num angles");
+		return false;
+	}
+
+	//Read num angle types
+	if (!md_buffered_reader_extract_line(&line, reader)) {
+		MD_LOG_ERROR("Failed to parse LAMMPS num angle types");
+		return false;
+	}
+	data->num_angle_types = parse_int(str_trim(line));
+	if (!data->num_angle_types) {
+		MD_LOG_ERROR("Failed to parse LAMMPS num angle types");
+		return false;
+	}
+
+	//Read num dihedrals
+	if (!md_buffered_reader_extract_line(&line, reader)) {
+		MD_LOG_ERROR("Failed to parse LAMMPS num dihedrals");
+		return false;
+	}
+	data->num_dihedrals = parse_int(str_trim(line));
+	if (!data->num_dihedrals) {
+		MD_LOG_ERROR("Failed to parse LAMMPS num dihedrals");
+		return false;
+	}
+
+	//Read num dihedral types
+	if (!md_buffered_reader_extract_line(&line, reader)) {
+		MD_LOG_ERROR("Failed to parse LAMMPS num dihedral types");
+		return false;
+	}
+	data->num_dihedral_types = parse_int(str_trim(line));
+	if (!data->num_dihedral_types) {
+		MD_LOG_ERROR("Failed to parse LAMMPS num dihedral types");
+		return false;
+	}
+
+	//Jump ahead to the Masses definition
+	int32_t masses_line_counter = 0;
+	do {
+		md_buffered_reader_extract_line(&line, reader);
+		if (masses_line_counter++ >= 1000) {
+			MD_LOG_ERROR("Could not find masses line after 1000 lines");
+			return false;
+		}
+	} while (!str_equal_cstr_n(line, "Masses", 6));
+
+	//Skip empty line
+	md_buffered_reader_skip_line(reader);
+
+	//Start reading the Masses data
+
+	for (int32_t i = 0; i < data->num_atom_types; i++) {
+		if (!md_buffered_reader_extract_line(&line, reader)) {
+			MD_LOG_ERROR("Failed to extract mass line");
+			return false;
+		}
+		if (extract_tokens(tokens, 2, &line) != 2) {
+			MD_LOG_ERROR("Wrong amount of mass tokens");
+			return false;
+		}
+
+		md_lammps_atom_mass_t* mass = &data->atom_type_mass;
+
+		mass->atom_idx = (int32_t)parse_int(tokens[0]);
+		mass->mass = (int32_t)parse_float(tokens[1]);
+	}
 
 	//Jump ahead to the Atoms definition
 	int32_t atoms_line_counter = 0;

--- a/src/md_lammps.c
+++ b/src/md_lammps.c
@@ -12,6 +12,21 @@
 
 #include <string.h>
 
+data_format_t* get_data_format(atom_style style) {
+	data_format_t* df;
+	switch (style)
+	{
+	default:
+		MD_LOG_ERROR("Invalid atom_style");
+		break;
+	case full:
+		data_format_t arr[10] = { ATOM_IDX, MOL_IDX, ATOM_TYPE, PARTIAL_CHARGE, ATOM_X, ATOM_Y, ATOM_Z, NX, NY, NZ };
+		df->len = 10;
+		df->ptr = arr;
+		return df;
+	}
+}
+
 static bool md_lammps_data_parse(md_lammps_data_t* data, md_buffered_reader_t* reader, struct md_allocator_i* alloc, data_format_t* data_format) {
 	ASSERT(data);
 	ASSERT(reader);

--- a/src/md_lammps.c
+++ b/src/md_lammps.c
@@ -46,7 +46,6 @@ static bool md_lammps_data_parse(md_lammps_data_t* data, md_buffered_reader_t* r
 	str_t line;
 	str_t tokens[16];
 
-	//lammps_atom_data_structure test_data_structure[] = { ATOM_IDX, MOL_IDX, ATOM_TYPE, PARTIAL_CHARGE, ATOM_COORD, ATOM_COORD, ATOM_COORD };
 
 	//Read the title of the file
 	{
@@ -271,14 +270,6 @@ static bool md_lammps_data_parse(md_lammps_data_t* data, md_buffered_reader_t* r
 
 			md_lammps_atom_t* atom = &data->atom_data[i];
 
-			/*
-			ATOM_IDX,
-			MOL_IDX,
-			ATOM_TYPE,
-			PARTIAL_CHARGE,
-			ATOM_COORD
-			*/
-
 			for (int64_t d = 0; d < data_format->len; d++) {
 				switch (data_format->ptr[d])
 				{
@@ -317,9 +308,6 @@ static bool md_lammps_data_parse(md_lammps_data_t* data, md_buffered_reader_t* r
 					break;
 				}
 			}
-
-			//str_copy_to_char_buf(atom->atom_type, sizeof(atom->atom_type), str_trim(str_substr(line, 5, 5)));
-			//str_copy_to_char_buf(atom->atom_name, sizeof(atom->atom_name), str_trim(str_substr(line, 10, 5)));
 		}
 	}
 
@@ -357,26 +345,6 @@ static bool md_lammps_data_parse(md_lammps_data_t* data, md_buffered_reader_t* r
 			bond->second_atom_idx = (int64_t)parse_int(tokens[3]);
 		}
 	}
-
-	/*
-
-	if (!md_buffered_reader_extract_line(&line, reader)) {
-		MD_LOG_ERROR("Failed to extract unitcell line");
-		return false;
-	}
-
-	const int64_t num_tokens = extract_float_tokens(tokens, ARRAY_SIZE(tokens), line);
-
-	if (num_tokens != 3) {
-		MD_LOG_ERROR("Failed to parse cell extent, expected 3 tokens, got %i", (int)num_tokens);
-		return false;
-	}
-
-	data->cell_ext[0] = (float)parse_float(tokens[0]);
-	data->cell_ext[1] = (float)parse_float(tokens[1]);
-	data->cell_ext[2] = (float)parse_float(tokens[2]);
-
-	*/
 
 	return true;
 }
@@ -494,6 +462,8 @@ bool md_lammps_init_from_file(md_molecule_t* mol, str_t filename, md_allocator_i
 	return success;
 }
 
+
+//Cant use interface as the format parameter is needed as well
 /*
 static md_molecule_loader_i lammps_api = {
 	lammps_init_from_str,

--- a/src/md_lammps.h
+++ b/src/md_lammps.h
@@ -13,6 +13,7 @@ struct md_allocator_i;
 struct md_molecule_t;
 struct md_molecule_loader_i;
 
+//Contains potential data format identifiers
 typedef enum lammps_atom_data_format {
 	ATOM_IDX,
 	MOL_IDX,
@@ -26,17 +27,21 @@ typedef enum lammps_atom_data_format {
 	NZ
 } lammps_atom_data_format;
 
+//Contains ptr to array with a data_format definition
 typedef struct data_format_t {
 	const lammps_atom_data_format* ptr;
 	int64_t len;
 } data_format_t;
 
+//Keyword for style that the data can have
 typedef enum atom_style {
 	full
 }atom_style;
 
+//Used to create the data_format with just a style keyword
 data_format_t* get_data_format(atom_style style);
 
+//Contains data about a single atom
 typedef struct md_lammps_atom_t {
 	int32_t atom_idx;
 	int32_t mol_idx;

--- a/src/md_lammps.h
+++ b/src/md_lammps.h
@@ -83,6 +83,9 @@ typedef struct md_lammps_data_t {
 	char title[256];
 
 	float cell_ext[3];
+	float xy;
+	float xz;
+	float yz;
 
 	int64_t num_atoms;
 	int32_t num_atom_types;

--- a/src/md_lammps.h
+++ b/src/md_lammps.h
@@ -63,8 +63,6 @@ typedef struct md_lammps_atom_t {
 	int32_t nx;
 	int32_t ny;
 	int32_t nz;
-	//char res_name[8];
-	//int32_t res_id; use mol_idx
 } md_lammps_atom_t;
 
 typedef struct md_lammps_atom_mass_t {

--- a/src/md_lammps.h
+++ b/src/md_lammps.h
@@ -31,6 +31,12 @@ typedef struct data_format_t {
 	int64_t len;
 } data_format_t;
 
+typedef enum atom_style {
+	full
+}atom_style;
+
+data_format_t* get_data_format(atom_style style);
+
 typedef struct md_lammps_atom_t {
 	int32_t atom_idx;
 	int32_t mol_idx;
@@ -62,10 +68,12 @@ bool md_lammps_data_parse_str(md_lammps_data_t* data, str_t str, struct md_alloc
 bool md_lammps_data_parse_file(md_lammps_data_t* data, str_t filename, struct md_allocator_i* alloc, data_format_t* data_format);
 void md_lammps_data_free(md_lammps_data_t* data, struct md_allocator_i* alloc);
 
+/*
 // Molecule
 bool md_lammps_molecule_init(struct md_molecule_t* mol, const md_lammps_data_t* lammps_data, struct md_allocator_i* alloc);
 
 struct md_molecule_loader_i* md_lammps_molecule_api();
+*/
 
 #ifdef __cplusplus
 }

--- a/src/md_lammps.h
+++ b/src/md_lammps.h
@@ -5,6 +5,8 @@
 
 #include <core/md_str.h>
 
+//All lammps units should have a 1:1 mapping to the md_molecule according to https://docs.lammps.org/2001/units.html
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/md_lammps.h
+++ b/src/md_lammps.h
@@ -27,8 +27,8 @@ typedef enum lammps_atom_data_format {
 	NX,
 	NY,
 	NZ,
-	res_name,
-	res_id
+	RES_NAME,
+	RES_ID
 } lammps_atom_data_format;
 
 static const lammps_atom_data_format DATA_FORMAT_FULL[] = {

--- a/src/md_lammps.h
+++ b/src/md_lammps.h
@@ -27,6 +27,10 @@ typedef enum lammps_atom_data_format {
 	NZ
 } lammps_atom_data_format;
 
+static const lammps_atom_data_format DATA_FORMAT_FULL[] = {
+	ATOM_IDX, MOL_IDX, ATOM_TYPE, PARTIAL_CHARGE, ATOM_X, ATOM_Y, ATOM_Z, NX, NY, NZ
+};
+
 //Contains ptr to array with a data_format definition
 typedef struct data_format_t {
 	const lammps_atom_data_format* ptr;
@@ -39,7 +43,7 @@ typedef enum atom_style {
 }atom_style;
 
 //Used to create the data_format with just a style keyword
-data_format_t* get_data_format(atom_style style);
+bool get_data_format(data_format_t* format, atom_style style);
 
 //Contains data about a single atom
 typedef struct md_lammps_atom_t {

--- a/src/md_lammps.h
+++ b/src/md_lammps.h
@@ -24,7 +24,9 @@ typedef enum lammps_atom_data_format {
 	ATOM_Z,
 	NX,
 	NY,
-	NZ
+	NZ,
+	res_name,
+	res_id
 } lammps_atom_data_format;
 
 static const lammps_atom_data_format DATA_FORMAT_FULL[] = {
@@ -57,6 +59,8 @@ typedef struct md_lammps_atom_t {
 	int32_t nx;
 	int32_t ny;
 	int32_t nz;
+	char res_name[8];
+	int32_t res_id;
 } md_lammps_atom_t;
 
 typedef struct md_lammps_atom_mass_t {

--- a/src/md_lammps.h
+++ b/src/md_lammps.h
@@ -70,12 +70,20 @@ typedef struct md_lammps_atom_mass_t {
 
 typedef struct md_lammps_data_t {
 	char title[256];
-	float cell_ext[3];
+
+	//float cell_ext[3];
+
+	int64_t num_atoms;
+	int32_t num_atom_types;
+	int64_t num_bonds;
+	int32_t num_bond_types;
+	int64_t num_angles;
+	int32_t num_angle_types;
+	int64_t num_dihedrals;
+	int32_t num_dihedral_types;
 
 	md_lammps_atom_mass_t* atom_type_mass;
 
-	// Field data
-	int64_t num_atoms;
 	md_lammps_atom_t* atom_data;
 } md_lammps_data_t;
 

--- a/src/md_lammps.h
+++ b/src/md_lammps.h
@@ -72,7 +72,7 @@ typedef struct md_lammps_atom_mass_t {
 	float mass;
 } md_lammps_atom_mass_t;
 
-float get_mass(md_lammps_atom_mass_t* masses, int32_t type, int32_t num_types);
+static float get_mass(md_lammps_atom_mass_t* masses, int32_t type, int32_t num_types);
 
 typedef struct md_lammps_atom_bond_t {
 	int64_t bond_idx;

--- a/src/md_lammps.h
+++ b/src/md_lammps.h
@@ -47,6 +47,8 @@ typedef enum atom_style {
 //Used to create the data_format with just a style keyword
 bool get_data_format(data_format_t* format, atom_style style);
 
+//
+
 //Contains data about a single atom
 typedef struct md_lammps_atom_t {
 	int32_t atom_idx;
@@ -59,14 +61,16 @@ typedef struct md_lammps_atom_t {
 	int32_t nx;
 	int32_t ny;
 	int32_t nz;
-	char res_name[8];
-	int32_t res_id;
+	//char res_name[8];
+	//int32_t res_id; use mol_idx
 } md_lammps_atom_t;
 
 typedef struct md_lammps_atom_mass_t {
-	int32_t atom_idx;
+	int32_t atom_type;
 	float mass;
 } md_lammps_atom_mass_t;
+
+float get_mass(md_lammps_atom_mass_t* masses, int32_t type, int32_t num_types);
 
 typedef struct md_lammps_atom_bond_t {
 	int64_t bond_idx;
@@ -78,7 +82,7 @@ typedef struct md_lammps_atom_bond_t {
 typedef struct md_lammps_data_t {
 	char title[256];
 
-	//float cell_ext[3];
+	float cell_ext[3];
 
 	int64_t num_atoms;
 	int32_t num_atom_types;
@@ -100,12 +104,12 @@ bool md_lammps_data_parse_str(md_lammps_data_t* data, str_t str, struct md_alloc
 bool md_lammps_data_parse_file(md_lammps_data_t* data, str_t filename, struct md_allocator_i* alloc, data_format_t* data_format);
 void md_lammps_data_free(md_lammps_data_t* data, struct md_allocator_i* alloc);
 
-/*
+
 // Molecule
 bool md_lammps_molecule_init(struct md_molecule_t* mol, const md_lammps_data_t* lammps_data, struct md_allocator_i* alloc);
 
-struct md_molecule_loader_i* md_lammps_molecule_api();
-*/
+//struct md_molecule_loader_i* md_lammps_molecule_api();
+
 
 #ifdef __cplusplus
 }

--- a/src/md_lammps.h
+++ b/src/md_lammps.h
@@ -50,6 +50,9 @@ typedef struct md_lammps_atom_t {
 	float x;
 	float y;
 	float z;
+	int32_t nx;
+	int32_t ny;
+	int32_t nz;
 } md_lammps_atom_t;
 
 typedef struct md_lammps_atom_mass_t {

--- a/src/md_lammps.h
+++ b/src/md_lammps.h
@@ -68,6 +68,13 @@ typedef struct md_lammps_atom_mass_t {
 	float mass;
 } md_lammps_atom_mass_t;
 
+typedef struct md_lammps_atom_bond_t {
+	int64_t bond_idx;
+	int32_t bond_type;
+	int64_t first_atom_idx;
+	int64_t second_atom_idx;
+} md_lammps_atom_bond_t;
+
 typedef struct md_lammps_data_t {
 	char title[256];
 
@@ -83,6 +90,7 @@ typedef struct md_lammps_data_t {
 	int32_t num_dihedral_types;
 
 	md_lammps_atom_mass_t* atom_type_mass;
+	md_lammps_atom_bond_t* bonds;
 
 	md_lammps_atom_t* atom_data;
 } md_lammps_data_t;

--- a/src/md_lammps.h
+++ b/src/md_lammps.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <core/md_str.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct md_allocator_i;
+struct md_molecule_t;
+struct md_molecule_loader_i;
+
+typedef enum lammps_atom_data_format {
+	ATOM_IDX,
+	MOL_IDX,
+	ATOM_TYPE,
+	PARTIAL_CHARGE,
+	ATOM_X,
+	ATOM_Y,
+	ATOM_Z,
+	NX,
+	NY,
+	NZ
+} lammps_atom_data_format;
+
+typedef struct data_format_t {
+	const lammps_atom_data_format* ptr;
+	int64_t len;
+} data_format_t;
+
+typedef struct md_lammps_atom_t {
+	int32_t atom_idx;
+	int32_t mol_idx;
+	int32_t atom_type;
+	float partial_charge;
+	float x;
+	float y;
+	float z;
+} md_lammps_atom_t;
+
+typedef struct md_lammps_atom_mass_t {
+	int32_t atom_idx;
+	float mass;
+} md_lammps_atom_mass_t;
+
+typedef struct md_lammps_data_t {
+	char title[256];
+	float cell_ext[3];
+
+	md_lammps_atom_mass_t* atom_type_mass;
+
+	// Field data
+	int64_t num_atoms;
+	md_lammps_atom_t* atom_data;
+} md_lammps_data_t;
+
+// Parse a text-blob as LAMMPS
+bool md_lammps_data_parse_str(md_lammps_data_t* data, str_t str, struct md_allocator_i* alloc, data_format_t* data_format);
+bool md_lammps_data_parse_file(md_lammps_data_t* data, str_t filename, struct md_allocator_i* alloc, data_format_t* data_format);
+void md_lammps_data_free(md_lammps_data_t* data, struct md_allocator_i* alloc);
+
+// Molecule
+bool md_lammps_molecule_init(struct md_molecule_t* mol, const md_lammps_data_t* lammps_data, struct md_allocator_i* alloc);
+
+struct md_molecule_loader_i* md_lammps_molecule_api();
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/src/md_lammps.h
+++ b/src/md_lammps.h
@@ -81,13 +81,15 @@ typedef struct md_lammps_atom_bond_t {
 	int64_t second_atom_idx;
 } md_lammps_atom_bond_t;
 
+typedef struct md_lammps_cell {
+	float x, y, z;
+	float xy, xz, yz;
+} md_lammps_cell;
+
 typedef struct md_lammps_data_t {
 	char title[256];
 
-	float cell_ext[3];
-	float xy;
-	float xz;
-	float yz;
+	md_lammps_cell cell_def;
 
 	int64_t num_atoms;
 	int32_t num_atom_types;

--- a/src/md_util.c
+++ b/src/md_util.c
@@ -2141,6 +2141,23 @@ mat3_t md_util_compute_unit_cell_basis(double a, double b, double c, double alph
     return M;
 }
 
+//Triclinic
+mat3_t md_util_compute_triclinic_unit_cell_basis(double x, double y, double z, double xy, double xz, double yz) {
+    mat3_t M = {
+        .col = {
+            {x, 0, 0},
+            {xy, y, 0},
+            {xz, yz, z},
+        },
+    };
+    return M;
+}
+
+md_unit_cell_t md_util_unit_cell_from_triclinic(double x, double y, double z, double xy, double xz, double yz) {
+    mat3_t matrix = md_util_compute_triclinic_unit_cell_basis(x, y, z, xy, xz, yz);
+    return md_util_unit_cell_from_matrix(matrix);
+}
+
 md_unit_cell_t md_util_unit_cell_from_extent(double x, double y, double z) {
     if (x == 0.0 && y == 0.0 && z == 0.0) {
         return (md_unit_cell_t) {0};

--- a/src/md_util.c
+++ b/src/md_util.c
@@ -362,14 +362,17 @@ bool md_util_element_from_mass(md_element_t element[], const float mass[], int64
     }
 
     if (!mass) {
-        MD_LOG_ERROR("element is null");
+        MD_LOG_ERROR("mass is null");
         return false;
     }
+
+    int64_t failed_matches = 0;
 
     const float eps = 1.0e-2f;
     for (int64_t i = 0; i < count; ++i) {
         md_element_t elem = 0;
         const float m = mass[i];
+        //Loop through the mass options, break when match is found
         for (uint8_t j = 1; j < (uint8_t)ARRAY_SIZE(element_atomic_mass); ++j) {
             if (fabs(m - element_atomic_mass[j]) < eps) {
                 elem = j;
@@ -378,9 +381,20 @@ bool md_util_element_from_mass(md_element_t element[], const float mass[], int64
         }
 
         element[i] = elem;
+        if (elem == 0) {
+            //Found no matching element for mass
+            failed_matches++;
+        }
     }
-
-    return false;
+    //Returns true if all masses found a matching element
+    //Elements with a value of 0 indicates no match
+    if (failed_matches == 0) {
+        return true;
+    }
+    else {
+        MD_LOG_ERROR("%i masses had no matching element", (int)failed_matches);
+        return false;
+    }
 }
 
 str_t md_util_element_symbol(md_element_t element) {

--- a/src/md_util.h
+++ b/src/md_util.h
@@ -119,6 +119,9 @@ md_unit_cell_t md_util_unit_cell_from_extent_and_angles(double a, double b, doub
 // Construct cell from mat3 basis
 md_unit_cell_t md_util_unit_cell_from_matrix(mat3_t M);
 
+//Construct cell from triclinic basis
+md_unit_cell_t md_util_unit_cell_from_triclinic(double x, double y, double z, double xy, double xz, double yz);
+
 // Computes an array of distances between two sets of coordinates in a periodic domain (cell)
 // out_dist:  Output array of distances, must have length of (num_a * num_b)
 // coord_a:   Array of coordinates (a)

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 
 project(md_unittest VERSION 0.1 LANGUAGES C)
 
-add_executable(md_unittest unittest.c "test_lammps.c")
+add_executable(md_unittest unittest.c)
 
 target_compile_definitions(md_unittest PRIVATE MD_UNITTEST_DATA_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/../test_data\" UTEST_USE_OLD_QPC ${MD_DEFINES})
 target_compile_options(md_unittest PRIVATE ${MD_FLAGS_EXT} ${MD_FLAGS_AVX} $<$<CONFIG:Debug>:${MD_FLAGS_DEB}> $<$<CONFIG:Release>:${MD_FLAGS_REL}>)
@@ -37,6 +37,7 @@ target_sources(md_unittest
     ${CMAKE_CURRENT_SOURCE_DIR}/test_xyz.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test_xvg.c
     ${CMAKE_CURRENT_SOURCE_DIR}/rmsd.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_lammps.c
   )
 
 # adapted from https://github.com/Kitware/CMake/blob/master/Modules/GoogleTest.cmake

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 
 project(md_unittest VERSION 0.1 LANGUAGES C)
 
-add_executable(md_unittest unittest.c)
+add_executable(md_unittest unittest.c "test_lammps.c")
 
 target_compile_definitions(md_unittest PRIVATE MD_UNITTEST_DATA_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/../test_data\" UTEST_USE_OLD_QPC ${MD_DEFINES})
 target_compile_options(md_unittest PRIVATE ${MD_FLAGS_EXT} ${MD_FLAGS_AVX} $<$<CONFIG:Debug>:${MD_FLAGS_DEB}> $<$<CONFIG:Release>:${MD_FLAGS_REL}>)

--- a/unittest/test_lammps.c
+++ b/unittest/test_lammps.c
@@ -23,6 +23,7 @@ UTEST(lammps, parse_small) {
     EXPECT_EQ(lammps_data.num_atom_types, 4);
     EXPECT_EQ(lammps_data.atom_type_mass[0].mass, 1.008f);
     EXPECT_EQ(lammps_data.bonds[0].second_atom_idx, 2);
+    EXPECT_EQ(lammps_data.xy, 0);
 
     
 

--- a/unittest/test_lammps.c
+++ b/unittest/test_lammps.c
@@ -1,0 +1,78 @@
+#include "utest.h"
+#include <string.h>
+
+#include <md_lammps.h>
+#include <md_trajectory.h>
+#include <md_molecule.h>
+#include <core/md_allocator.h>
+#include <core/md_os.h>
+#include <core/md_log.h>
+
+UTEST(lammps, parse_small) {
+    md_allocator_i* alloc = md_heap_allocator;
+
+    str_t path = STR(MD_UNITTEST_DATA_DIR"/Water_Ethane_Cubic_Init.data");
+    md_lammps_data_t lammps_data = {0};
+    data_format_t *formatPtr, format;
+    formatPtr = &format;
+    get_data_format(formatPtr, full);
+
+    bool result = md_lammps_data_parse_file(&lammps_data, path, alloc, formatPtr);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(lammps_data.num_atoms, 7800);
+
+    /*
+
+    md_molecule_t mol = {0};
+
+    md_gro_molecule_init(&mol, &gro_data, alloc);
+    for (int64_t i = 0; i < mol.atom.count; ++i) {
+        EXPECT_EQ(mol.atom.x[i], gro_data.atom_data[i].x * 10.0f);
+        EXPECT_EQ(mol.atom.y[i], gro_data.atom_data[i].y * 10.0f);
+        EXPECT_EQ(mol.atom.z[i], gro_data.atom_data[i].z * 10.0f);
+    }
+    md_molecule_free(&mol, alloc);
+
+    EXPECT_TRUE(md_gro_molecule_api()->init_from_file(&mol, path, alloc));
+    for (int64_t i = 0; i < mol.atom.count; ++i) {
+        EXPECT_EQ(mol.atom.x[i], gro_data.atom_data[i].x * 10.0f);
+        EXPECT_EQ(mol.atom.y[i], gro_data.atom_data[i].y * 10.0f);
+        EXPECT_EQ(mol.atom.z[i], gro_data.atom_data[i].z * 10.0f);
+    }
+
+    */
+
+    md_lammps_data_free(&lammps_data, alloc);
+}
+
+/*
+UTEST(gro, parse_big) {
+    md_allocator_i* alloc = md_heap_allocator;
+
+    str_t path = STR(MD_UNITTEST_DATA_DIR"/centered.gro");
+    md_gro_data_t gro_data = { 0 };
+    bool result = md_gro_data_parse_file(&gro_data, path, alloc);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(gro_data.num_atoms, 161742);
+
+    md_molecule_t mol = { 0 };
+
+    md_gro_molecule_init(&mol, &gro_data, alloc);
+    for (int64_t i = 0; i < mol.atom.count; ++i) {
+        EXPECT_EQ(mol.atom.x[i], gro_data.atom_data[i].x * 10.0f);
+        EXPECT_EQ(mol.atom.y[i], gro_data.atom_data[i].y * 10.0f);
+        EXPECT_EQ(mol.atom.z[i], gro_data.atom_data[i].z * 10.0f);
+    }
+    md_molecule_free(&mol, alloc);
+
+    EXPECT_TRUE(md_gro_molecule_api()->init_from_file(&mol, path, alloc));
+    for (int64_t i = 0; i < mol.atom.count; ++i) {
+        EXPECT_EQ(mol.atom.x[i], gro_data.atom_data[i].x * 10.0f);
+        EXPECT_EQ(mol.atom.y[i], gro_data.atom_data[i].y * 10.0f);
+        EXPECT_EQ(mol.atom.z[i], gro_data.atom_data[i].z * 10.0f);
+    }
+
+    md_gro_data_free(&gro_data, alloc);
+}
+
+*/

--- a/unittest/test_lammps.c
+++ b/unittest/test_lammps.c
@@ -23,7 +23,7 @@ UTEST(lammps, parse_small) {
     EXPECT_EQ(lammps_data.num_atom_types, 4);
     EXPECT_EQ(lammps_data.atom_type_mass[0].mass, 1.008f);
     EXPECT_EQ(lammps_data.bonds[0].second_atom_idx, 2);
-    EXPECT_EQ(lammps_data.xy, 0);
+    EXPECT_EQ(lammps_data.cell_def.xy, 0);
 
     
 

--- a/unittest/test_lammps.c
+++ b/unittest/test_lammps.c
@@ -22,6 +22,7 @@ UTEST(lammps, parse_small) {
     EXPECT_EQ(lammps_data.num_atoms, 7800);
     EXPECT_EQ(lammps_data.num_atom_types, 4);
     EXPECT_EQ(lammps_data.atom_type_mass[0].mass, 1.008f);
+    EXPECT_EQ(lammps_data.bonds[0].second_atom_idx, 2);
 
     /*
 

--- a/unittest/test_lammps.c
+++ b/unittest/test_lammps.c
@@ -24,26 +24,29 @@ UTEST(lammps, parse_small) {
     EXPECT_EQ(lammps_data.atom_type_mass[0].mass, 1.008f);
     EXPECT_EQ(lammps_data.bonds[0].second_atom_idx, 2);
 
-    /*
+    
 
     md_molecule_t mol = {0};
 
-    md_gro_molecule_init(&mol, &gro_data, alloc);
+    md_lammps_molecule_init(&mol, &lammps_data, alloc);
     for (int64_t i = 0; i < mol.atom.count; ++i) {
-        EXPECT_EQ(mol.atom.x[i], gro_data.atom_data[i].x * 10.0f);
-        EXPECT_EQ(mol.atom.y[i], gro_data.atom_data[i].y * 10.0f);
-        EXPECT_EQ(mol.atom.z[i], gro_data.atom_data[i].z * 10.0f);
+        EXPECT_EQ(mol.atom.x[i], lammps_data.atom_data[i].x * 10.0f);
+        EXPECT_EQ(mol.atom.y[i], lammps_data.atom_data[i].y * 10.0f);
+        EXPECT_EQ(mol.atom.z[i], lammps_data.atom_data[i].z * 10.0f);
+        EXPECT_NE(mol.atom.mass[i], 0);
     }
     md_molecule_free(&mol, alloc);
 
-    EXPECT_TRUE(md_gro_molecule_api()->init_from_file(&mol, path, alloc));
+    /*
+    EXPECT_TRUE(lammps_init_from_file(&mol, path, alloc, formatPtr));
     for (int64_t i = 0; i < mol.atom.count; ++i) {
-        EXPECT_EQ(mol.atom.x[i], gro_data.atom_data[i].x * 10.0f);
-        EXPECT_EQ(mol.atom.y[i], gro_data.atom_data[i].y * 10.0f);
-        EXPECT_EQ(mol.atom.z[i], gro_data.atom_data[i].z * 10.0f);
+        EXPECT_EQ(mol.atom.x[i], lammps_data.atom_data[i].x * 10.0f);
+        EXPECT_EQ(mol.atom.y[i], lammps_data.atom_data[i].y * 10.0f);
+        EXPECT_EQ(mol.atom.z[i], lammps_data.atom_data[i].z * 10.0f);
     }
-
     */
+
+    
 
     md_lammps_data_free(&lammps_data, alloc);
 }

--- a/unittest/test_lammps.c
+++ b/unittest/test_lammps.c
@@ -20,6 +20,8 @@ UTEST(lammps, parse_small) {
     bool result = md_lammps_data_parse_file(&lammps_data, path, alloc, formatPtr);
     EXPECT_TRUE(result);
     EXPECT_EQ(lammps_data.num_atoms, 7800);
+    EXPECT_EQ(lammps_data.num_atom_types, 4);
+    EXPECT_EQ(lammps_data.atom_type_mass[0].mass, 1.008f);
 
     /*
 

--- a/unittest/test_lammps.c
+++ b/unittest/test_lammps.c
@@ -34,6 +34,7 @@ UTEST(lammps, parse_small) {
         EXPECT_EQ(mol.atom.y[i], lammps_data.atom_data[i].y * 10.0f);
         EXPECT_EQ(mol.atom.z[i], lammps_data.atom_data[i].z * 10.0f);
         EXPECT_NE(mol.atom.mass[i], 0);
+        EXPECT_NE(mol.atom.element[i], 0);
     }
     md_molecule_free(&mol, alloc);
 

--- a/unittest/test_lammps.c
+++ b/unittest/test_lammps.c
@@ -31,9 +31,9 @@ UTEST(lammps, parse_small) {
 
     md_lammps_molecule_init(&mol, &lammps_data, alloc);
     for (int64_t i = 0; i < mol.atom.count; ++i) {
-        EXPECT_EQ(mol.atom.x[i], lammps_data.atom_data[i].x * 10.0f);
-        EXPECT_EQ(mol.atom.y[i], lammps_data.atom_data[i].y * 10.0f);
-        EXPECT_EQ(mol.atom.z[i], lammps_data.atom_data[i].z * 10.0f);
+        EXPECT_EQ(mol.atom.x[i], lammps_data.atom_data[i].x);
+        EXPECT_EQ(mol.atom.y[i], lammps_data.atom_data[i].y);
+        EXPECT_EQ(mol.atom.z[i], lammps_data.atom_data[i].z);
         EXPECT_NE(mol.atom.mass[i], 0);
         EXPECT_NE(mol.atom.element[i], 0);
     }

--- a/unittest/test_lammps.c
+++ b/unittest/test_lammps.c
@@ -34,7 +34,7 @@ UTEST(lammps, parse_small) {
         EXPECT_EQ(mol.atom.x[i], lammps_data.atom_data[i].x);
         EXPECT_EQ(mol.atom.y[i], lammps_data.atom_data[i].y);
         EXPECT_EQ(mol.atom.z[i], lammps_data.atom_data[i].z);
-        EXPECT_NE(mol.atom.mass[i], 0);
+        EXPECT_NE(mol.atom.mass[i], 0.0f);
         EXPECT_NE(mol.atom.element[i], 0);
     }
     md_molecule_free(&mol, alloc);

--- a/unittest/test_lammps.c
+++ b/unittest/test_lammps.c
@@ -37,50 +37,8 @@ UTEST(lammps, parse_small) {
         EXPECT_NE(mol.atom.mass[i], 0.0f);
         EXPECT_NE(mol.atom.element[i], 0);
     }
+
     md_molecule_free(&mol, alloc);
-
-    /*
-    EXPECT_TRUE(lammps_init_from_file(&mol, path, alloc, formatPtr));
-    for (int64_t i = 0; i < mol.atom.count; ++i) {
-        EXPECT_EQ(mol.atom.x[i], lammps_data.atom_data[i].x * 10.0f);
-        EXPECT_EQ(mol.atom.y[i], lammps_data.atom_data[i].y * 10.0f);
-        EXPECT_EQ(mol.atom.z[i], lammps_data.atom_data[i].z * 10.0f);
-    }
-    */
-
-    
 
     md_lammps_data_free(&lammps_data, alloc);
 }
-
-/*
-UTEST(gro, parse_big) {
-    md_allocator_i* alloc = md_heap_allocator;
-
-    str_t path = STR(MD_UNITTEST_DATA_DIR"/centered.gro");
-    md_gro_data_t gro_data = { 0 };
-    bool result = md_gro_data_parse_file(&gro_data, path, alloc);
-    EXPECT_TRUE(result);
-    EXPECT_EQ(gro_data.num_atoms, 161742);
-
-    md_molecule_t mol = { 0 };
-
-    md_gro_molecule_init(&mol, &gro_data, alloc);
-    for (int64_t i = 0; i < mol.atom.count; ++i) {
-        EXPECT_EQ(mol.atom.x[i], gro_data.atom_data[i].x * 10.0f);
-        EXPECT_EQ(mol.atom.y[i], gro_data.atom_data[i].y * 10.0f);
-        EXPECT_EQ(mol.atom.z[i], gro_data.atom_data[i].z * 10.0f);
-    }
-    md_molecule_free(&mol, alloc);
-
-    EXPECT_TRUE(md_gro_molecule_api()->init_from_file(&mol, path, alloc));
-    for (int64_t i = 0; i < mol.atom.count; ++i) {
-        EXPECT_EQ(mol.atom.x[i], gro_data.atom_data[i].x * 10.0f);
-        EXPECT_EQ(mol.atom.y[i], gro_data.atom_data[i].y * 10.0f);
-        EXPECT_EQ(mol.atom.z[i], gro_data.atom_data[i].z * 10.0f);
-    }
-
-    md_gro_data_free(&gro_data, alloc);
-}
-
-*/


### PR DESCRIPTION
# In this PR
-  Adds support for parsing lammps .data files and converting them into md_molecule. See md_lammps.h/c
- Adds a test file of type .data
- Adds a unit test based on a .data file
- Adds benchmark using the test file
- Changes to md_util_element_from_mass as it would always return false before
- Adds support for triclinic data to mat3/unit_cell
# md_lammps.h/c
md_lammps build on gro, but have some special considerations

## Atom data variation
The given data on a atom definition row can vary based on the type of style that the user had picked when generating the .data file. For example, the most common type seems to be "full", which would generate the data with the following fields and order: `ATOM_IDX, MOL_IDX, ATOM_TYPE, PARTIAL_CHARGE, ATOM_X, ATOM_Y, ATOM_Z, NX, NY, NZ`
When calling functions to parse lammps files, the user needs to provide a "format" array of these keywords from the `lammps_atom_data_format`enum or by using the helper function `bool get_data_format(data_format_t* format, atom_style style)` with a style keyword. The format can then be used to switch on the different types and assign each token to the correct data.

## Triclinic parsing
Lammps data can be simulated both with a cubic and triclinic structure. In the case of a triclinic cell, an additional line is added in the cell definition which gives xy, xz and yz. This can then be used to create a [Triclinic simulations box from matrix](https://docs.lammps.org/Howto_triclinic.html) which is done in `mat3_t md_util_compute_triclinic_unit_cell_basis`

## res_id and mol_idx
The res_id in md_molecule seems to be equivalent to mol_idx in .data